### PR TITLE
Implement CRUD Functionality for Meeting Resource

### DIFF
--- a/Server/controllers/meeting/_routes.js
+++ b/Server/controllers/meeting/_routes.js
@@ -1,5 +1,13 @@
 const express = require('express');
+const meeting = require('./meeting');
 
 const router = express.Router();
+
+router.post('/add', meeting.add);
+router.get('/', meeting.index);
+router.get('/:id', meeting.view);
+router.put('/edit/:id', meeting.edit);
+router.delete('/delete/:id', meeting.deleteData);
+router.post('/deleteMany', meeting.deleteMany);
 
 module.exports = router;

--- a/Server/controllers/meeting/meeting.js
+++ b/Server/controllers/meeting/meeting.js
@@ -1,14 +1,237 @@
 const MeetingHistory = require('../../model/schema/meeting');
 const mongoose = require('mongoose');
 
-const add = async (req, res) => {};
+const add = async (req, res) => {
+  try {
+    const {
+      agenda,
+      attendes,
+      attendesLead,
+      location,
+      dateTime,
+      notes,
+      createBy,
+    } = req.body;
 
-const index = async (req, res) => {};
+    // Ensure createBy is provided, as it's required by the schema
+    if (!createBy) {
+      return res.status(400).json({ error: 'Created by user ID is required.' });
+    }
 
-const view = async (req, res) => {};
+    const newMeeting = new MeetingHistory({
+      agenda,
+      attendes,
+      attendesLead,
+      location,
+      dateTime,
+      notes,
+      createBy,
+      timestamp: new Date(), // Set current timestamp
+    });
 
-const deleteData = async (req, res) => {};
+    await newMeeting.save();
+    res.status(201).json(newMeeting);
+  } catch (err) {
+    console.error('Failed to create Meeting:', err);
+    res
+      .status(400)
+      .json({ error: 'Failed to create Meeting', details: err.message });
+  }
+};
 
-const deleteMany = async (req, res) => {};
+const index = async (req, res) => {
+  try {
+    const query = { deleted: false };
 
-module.exports = { add, index, view, deleteData, deleteMany };
+    const meetings = await MeetingHistory.find(query)
+      .populate({
+        path: 'createBy',
+        select: 'firstName lastName email',
+        match: { deleted: false },
+      })
+      .populate({
+        path: 'attendes',
+        select: 'firstName lastName email',
+        match: { deleted: false },
+      })
+      .populate({
+        path: 'attendesLead',
+        select: 'leadName leadEmail',
+        match: { deleted: false },
+      })
+      .exec();
+
+    const filteredMeetings = meetings.filter(
+      (meeting) =>
+        meeting.createBy !== null &&
+        (meeting.attendes.every((attendee) => attendee !== null) ||
+          meeting.attendes.length === 0) &&
+        (meeting.attendesLead.every((attendee) => attendee !== null) ||
+          meeting.attendesLead.length === 0)
+    );
+
+    res.status(200).json(filteredMeetings);
+  } catch (err) {
+    console.error('Failed to retrieve Meetings:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to retrieve Meetings', details: err.message });
+  }
+};
+
+const view = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: 'Invalid Meeting ID.' });
+    }
+
+    const meeting = await MeetingHistory.findOne({ _id: id, deleted: false })
+      .populate({
+        path: 'createBy',
+        select: 'firstName lastName email',
+        match: { deleted: false },
+      })
+      .populate({
+        path: 'attendes',
+        select: 'firstName lastName email',
+        match: { deleted: false },
+      })
+      .populate({
+        path: 'attendesLead',
+        select: 'leadName leadEmail',
+        match: { deleted: false },
+      })
+      .exec();
+
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ message: 'Meeting not found or has been deleted.' });
+    }
+
+    res.status(200).json(meeting);
+  } catch (err) {
+    console.error('Failed to retrieve Meeting:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to retrieve Meeting', details: err.message });
+  }
+};
+
+// Add for achieving CRUD operations
+const edit = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updateData = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: 'Invalid Meeting ID.' });
+    }
+
+    if (updateData.deleted !== undefined) {
+      delete updateData.deleted;
+    }
+
+    const updatedMeeting = await MeetingHistory.findByIdAndUpdate(
+      { _id: id, deleted: false },
+      { $set: updateData },
+      { new: true, runValidators: true }
+    );
+
+    if (!updatedMeeting) {
+      return res
+        .status(404)
+        .json({ message: 'Meeting not found or has been deleted.' });
+    }
+
+    res.status(200).json(updatedMeeting);
+  } catch (err) {
+    console.error('Failed to update Meeting:', err);
+    res
+      .status(400)
+      .json({ error: 'Failed to update Meeting', details: err.message });
+  }
+};
+
+const deleteData = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: 'Invalid Meeting ID.' });
+    }
+
+    const meeting = await MeetingHistory.findByIdAndUpdate(
+      { _id: id, deleted: false },
+      { $set: { deleted: true } },
+      { new: true }
+    );
+
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ message: 'Meeting not found or already deleted.' });
+    }
+
+    res.status(200).json({ message: 'Meeting deleted successfully.', meeting });
+  } catch (err) {
+    console.error('Failed to delete Meeting:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to delete Meeting', details: err.message });
+  }
+};
+
+const deleteMany = async (req, res) => {
+  try {
+    const { ids } = req.body;
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res
+        .status(400)
+        .json({ error: 'An array of Meeting IDs is required.' });
+    }
+
+    // Validate all IDs are valid ObjectIds
+    const invalidIds = ids.filter((id) => !mongoose.Types.ObjectId.isValid(id));
+    if (invalidIds.length > 0) {
+      return res.status(400).json({
+        error: 'One or more invalid Meeting IDs provided.',
+        invalidIds,
+      });
+    }
+
+    const result = await MeetingHistory.updateMany(
+      { _id: { $in: ids }, deleted: false },
+      { $set: { deleted: true } }
+    );
+
+    if (result.matchedCount === 0) {
+      return res.status(404).json({
+        message: 'No meetings found to delete with the provided IDs.',
+      });
+    }
+
+    res.status(200).json({
+      message: `${result.modifiedCount} meetings deleted successfully.`,
+      result,
+    });
+  } catch (err) {
+    console.error('Failed to delete multiple Meetings:', err);
+    res.status(500).json({
+      error: 'Failed to delete multiple Meetings',
+      details: err.message,
+    });
+  }
+};
+
+module.exports = {
+  add,
+  index,
+  view,
+  edit,
+  deleteData,
+  deleteMany,
+};

--- a/Server/model/schema/meeting.js
+++ b/Server/model/schema/meeting.js
@@ -5,13 +5,13 @@ const meetingHistory = new mongoose.Schema({
   attendes: [
     {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'Contact',
+      ref: 'Contacts',
     },
   ],
   attendesLead: [
     {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'Lead',
+      ref: 'Leads',
     },
   ],
   location: String,
@@ -22,7 +22,7 @@ const meetingHistory = new mongoose.Schema({
   createBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
-    require: true,
+    required: true,
   },
   timestamp: {
     type: Date,


### PR DESCRIPTION
### Title
Implement CRUD Functionality for Meeting Resource

### Description
This pull request introduces a complete set of CRUD (Create, Read, Update, Delete) functionalities for the `Meeting` resource.


### Changes
- **API Routes:** Added new endpoints in `Server/controllers/meeting/_routes.js` to handle `add`, `index`, `view`, `edit`, `deleteData`, and `deleteMany` operations for meetings.
- **Controller Logic:** Implemented controller methods in `Server/controllers/meeting/meeting.js` to:
    - `add`: Create a new meeting with validation for required fields.
    - `index`: Fetch all non-deleted meetings, populating `createBy`, `attendes`, and `attendesLead` fields.
    - `view`: Retrieve a single meeting by its ID, ensuring it has not been deleted.
    - `edit`: Update an existing meeting with proper validation.
    - `deleteData` / `deleteMany`: Soft-delete one or more meetings by setting the `deleted` flag to `true`.
- **Schema Updates:** Made adjustments in `Server/model/schema/meeting.js`:
    - Corrected the `ref` for `attendes` to `Contacts` and `attendesLead` to `Leads`.
    - Fixed a validation typo in the `createBy` field from `require` to `required`.

### How to Test
1.  **Create a Meeting:** Send a `POST` request to the `/api/meeting/add` endpoint with valid meeting data.
2.  **List Meetings:** Send a `GET` request to the `/api/meeting` endpoint to retrieve a list of all meetings.
3.  **View a Meeting:** Send a `GET` request to `/api/meeting/:id` using the ID from the created meeting to fetch its details.
4.  **Edit a Meeting:** Send a `PUT` request to `/api/meeting/:id` with updated data to modify the meeting.
5.  **Delete a Meeting:** Send a `DELETE` request to `/api/meeting/delete/:id` to soft-delete the meeting. Verify it no longer appears in the main list but is still in the database with `deleted: true`.

### Notes
